### PR TITLE
Add testing with mock objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>pl.put.poznan</groupId>
     <artifactId>text-transformer</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
 
 	<properties>
         <java.version>17</java.version>
@@ -56,6 +56,19 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/pl/put/poznan/transformer/logic/AbbrToWordDecorator.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/AbbrToWordDecorator.java
@@ -1,6 +1,6 @@
 package pl.put.poznan.transformer.logic;
 
-import static pl.put.poznan.transformer.logic.TextTransformer.wordsAndAbbrDictionary;
+//import static pl.put.poznan.transformer.logic.TextTransformer.wordsAndAbbrDictionary;
 
 /**
  * This is a part of the decorator pattern used in this project (concrete decorator).
@@ -11,9 +11,10 @@ public class AbbrToWordDecorator extends TextDecorator {
     /**
      * Constructs a AbbrToWordDecorator with the specified transformer.
      * @param transformer the Transformer object to be decorated
+     * @param dictionary the dictionary containing words and abbreviations
      */
-    public  AbbrToWordDecorator(Transformer transformer) {
-        super(transformer);
+    public  AbbrToWordDecorator(Transformer transformer, WordsAndAbbrDictionary dictionary) {
+        super(transformer, dictionary);
     }
 
     /**

--- a/src/main/java/pl/put/poznan/transformer/logic/NumberToTextDecorator.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/NumberToTextDecorator.java
@@ -1,6 +1,6 @@
 package pl.put.poznan.transformer.logic;
 
-import static pl.put.poznan.transformer.logic.TextTransformer.numberDictionary;
+//import pl.put.poznan.transformer.logic.TextTransformer.numberDictionary;
 
 /**
  * This is NumberToTextClass which transforms numbers (integers and floats smaller or equal 1000 and floats with max two decimal places)
@@ -8,12 +8,14 @@ import static pl.put.poznan.transformer.logic.TextTransformer.numberDictionary;
 * */
 
 public class NumberToTextDecorator extends TextDecorator  {
-
     /**
      * Class constructor
-     * @param transformer Inherited class
+     * @param transformer the Transformer object to be decorated
+     * @param numberDictionary the dictionary containing numbers written in Polish
      */
-    public NumberToTextDecorator(Transformer transformer) { super(transformer); }
+    public NumberToTextDecorator(Transformer transformer, NumberDictionary numberDictionary) {
+        super(transformer, numberDictionary);
+    }
 
     /**
      * Function to check if given string is a integer

--- a/src/main/java/pl/put/poznan/transformer/logic/TextDecorator.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/TextDecorator.java
@@ -12,6 +12,8 @@ public class TextDecorator implements Transformer {
      * A reference to the "component" being decorated.
      */
     protected Transformer transformer;
+    public NumberDictionary numberDictionary;
+    public WordsAndAbbrDictionary wordsAndAbbrDictionary;
 
     /**
      * Constructs a TextDecorator with the specified transformer.
@@ -19,6 +21,26 @@ public class TextDecorator implements Transformer {
      */
     public TextDecorator(Transformer transformer) {
         this.transformer = transformer;
+    }
+
+    /**
+     * Constructs a TextDecorator with the specified transformer and number dictionary.
+     * @param transformer the Transformer object to be decorated
+     * @param numberDictionary the dictionary with numbers written in Polish
+     */
+    public TextDecorator(Transformer transformer, NumberDictionary numberDictionary) {
+        this.transformer = transformer;
+        this.numberDictionary = numberDictionary;
+    }
+
+    /**
+     * Constructs a TextDecorator with the specified transformer and words and abbreviations dictionary.
+     * @param transformer the Transformer object to be decorated
+     * @param wordsAndAbbrDictionary the dictionary with words and abbreviations
+     */
+    public TextDecorator(Transformer transformer, WordsAndAbbrDictionary wordsAndAbbrDictionary) {
+        this.transformer = transformer;
+        this.wordsAndAbbrDictionary = wordsAndAbbrDictionary;
     }
 
     /**

--- a/src/main/java/pl/put/poznan/transformer/logic/TextTransformer.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/TextTransformer.java
@@ -10,17 +10,24 @@ public class TextTransformer {
      * Field for storing all transformations to be applied with current instance of TextTransformer class
      */
     private final String[] transforms;
+    /**
+     * Dictionary containing numbers and their names in Polish
+     */
+    public NumberDictionary numberDictionary;
+    /**
+     * Dictionary containing words and abbreviations in Polish
+     */
+    public WordsAndAbbrDictionary wordsAndAbbrDictionary;
 
     /**
      * TextTransformer class constructor
      * @param transforms list of strings representing transformations
      */
-    public TextTransformer(String[] transforms){
+    public TextTransformer(String[] transforms, NumberDictionary numberDictionary, WordsAndAbbrDictionary wordsAndAbbrDictionary) {
         this.transforms = transforms;
+        this.numberDictionary = numberDictionary;
+        this.wordsAndAbbrDictionary = wordsAndAbbrDictionary;
     }
-
-    public static final NumberDictionary numberDictionary = new NumberDictionary("src/main/resources/numbersDictionarySource.csv");
-    public static final WordsAndAbbrDictionary wordsAndAbbrDictionary = new WordsAndAbbrDictionary("src/main/resources/wordsAndAbbrDictionary.csv");
 
     /**
      * Performs all transformations specified for this object
@@ -38,9 +45,9 @@ public class TextTransformer {
                 case "lower" -> new LowercaseDecorator(container);
                 case "capitalize" -> new CapitalizeDecorator(container);
                 case "reverse" -> new ReverseDecorator(container);
-                case "numbersToText" -> new NumberToTextDecorator(container);
-                case "wordToAbbr" -> new WordToAbbrDecorator(container);
-                case "abbrToWord" -> new AbbrToWordDecorator(container);
+                case "numbersToText" -> new NumberToTextDecorator(container, numberDictionary);
+                case "wordToAbbr" -> new WordToAbbrDecorator(container, wordsAndAbbrDictionary);
+                case "abbrToWord" -> new AbbrToWordDecorator(container, wordsAndAbbrDictionary);
                 default -> container;
             };
             newText = transformer.transformText();

--- a/src/main/java/pl/put/poznan/transformer/logic/WordToAbbrDecorator.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/WordToAbbrDecorator.java
@@ -1,6 +1,6 @@
 package pl.put.poznan.transformer.logic;
 
-import static pl.put.poznan.transformer.logic.TextTransformer.wordsAndAbbrDictionary;
+//import static pl.put.poznan.transformer.logic.TextTransformer.wordsAndAbbrDictionary;
 
 /**
  * This is a part of the decorator pattern used in this project (concrete decorator).
@@ -11,9 +11,10 @@ public class WordToAbbrDecorator extends TextDecorator{
     /**
      * Constructs a WordToAbbrDecorator with the specified transformer.
      * @param transformer the Transformer object to be decorated
+     * @param dictionary the dictionary with words and abbreviations
      */
-    public WordToAbbrDecorator(Transformer transformer) {
-        super(transformer);
+    public WordToAbbrDecorator(Transformer transformer, WordsAndAbbrDictionary dictionary) {
+        super(transformer, dictionary);
     }
 
     /**

--- a/src/main/java/pl/put/poznan/transformer/rest/TextTransformerController.java
+++ b/src/main/java/pl/put/poznan/transformer/rest/TextTransformerController.java
@@ -5,7 +5,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import pl.put.poznan.transformer.logic.JsonParser;
+import pl.put.poznan.transformer.logic.NumberDictionary;
 import pl.put.poznan.transformer.logic.TextTransformer;
+import pl.put.poznan.transformer.logic.WordsAndAbbrDictionary;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -16,6 +18,8 @@ import java.util.Map;
 public class TextTransformerController {
 
     private static final Logger logger = LoggerFactory.getLogger(TextTransformerController.class);
+    public static final NumberDictionary numberDictionary = new NumberDictionary("src/main/resources/numbersDictionarySource.csv");
+    public static final WordsAndAbbrDictionary wordsAndAbbrDictionary = new WordsAndAbbrDictionary("src/main/resources/wordsAndAbbrDictionary.csv");
 
     @GetMapping(value = "/transform", produces = "application/json")
     public String get(@RequestParam(value = "text", defaultValue = "LoReM IpSuM!") String text,
@@ -26,7 +30,7 @@ public class TextTransformerController {
         logger.debug(Arrays.toString(transforms));
 
         // perform the transformation, you should run your logic here, below is just a silly example
-        TextTransformer transformer = new TextTransformer(transforms);
+        TextTransformer transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
         return parser.ResToJson(transformer.transform(text));
     }
 
@@ -44,7 +48,7 @@ public class TextTransformerController {
         logger.debug(Arrays.toString(transforms));
 
         // perform the transformation, you should run your logic here, below is just a silly example
-        TextTransformer transformer = new TextTransformer(transforms);
+        TextTransformer transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
 
         return parser.ResToJson(transformer.transform(text));
     }
@@ -67,7 +71,7 @@ public class TextTransformerController {
         logger.debug(Arrays.toString(transforms));
 
         // perform the transformation, you should run your logic here, below is just a silly example
-        TextTransformer transformer = new TextTransformer(transforms);
+        TextTransformer transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
 
         modelAndView.addObject("processedText", transformer.transform(text));
         modelAndView.addObject("transforms", String.join(", ", transforms));

--- a/src/test/java/pl/put/poznan/transformer/logic/AbbrToWordDecoratorTest.java
+++ b/src/test/java/pl/put/poznan/transformer/logic/AbbrToWordDecoratorTest.java
@@ -4,22 +4,33 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AbbrToWordDecoratorTest {
     TextContainer container;
     AbbrToWordDecorator decorator;
+    WordsAndAbbrDictionary wordsAndAbbrDictionary;
 
     String text = "Lek. to m.in. np. ul. tzw. bigos.";
     String expected = "Lekarz to między innymi na przykład ulica tak zwany bigos.";
 
     @BeforeEach
     void setUp() {
+        wordsAndAbbrDictionary = mock(WordsAndAbbrDictionary.class);
         container = new TextContainer(text);
-        decorator = new AbbrToWordDecorator(container);
+        decorator = new AbbrToWordDecorator(container, wordsAndAbbrDictionary);
     }
 
     @Test
-    void testWordToAbbr() {
+    void testAbbrToWord() {
+        String[] abbrs = {"np.", "m.in.", "Lek.", "ul.", "tzw."};
+        when(wordsAndAbbrDictionary.getListOfAbbrs()).thenReturn(abbrs);
+        when(wordsAndAbbrDictionary.getWordFromAbbr(abbrs[0])).thenReturn("na przykład");
+        when(wordsAndAbbrDictionary.getWordFromAbbr(abbrs[1])).thenReturn("między innymi");
+        when(wordsAndAbbrDictionary.getWordFromAbbr(abbrs[2])).thenReturn("Lekarz");
+        when(wordsAndAbbrDictionary.getWordFromAbbr(abbrs[3])).thenReturn("ulica");
+        when(wordsAndAbbrDictionary.getWordFromAbbr(abbrs[4])).thenReturn("tak zwany");
         assertEquals(expected, decorator.transformText());
     }
 }

--- a/src/test/java/pl/put/poznan/transformer/logic/CapitalizeDecoratorTest.java
+++ b/src/test/java/pl/put/poznan/transformer/logic/CapitalizeDecoratorTest.java
@@ -2,6 +2,7 @@ package pl.put.poznan.transformer.logic;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/pl/put/poznan/transformer/logic/NumberToTextDecoratorTest.java
+++ b/src/test/java/pl/put/poznan/transformer/logic/NumberToTextDecoratorTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class NumberToTextDecoratorTest {
     TextContainer container;
     NumberToTextDecorator decorator;
+    NumberDictionary numberDictionary;
     String text = "This is 0.1 0.01 0.06 2.54 78.95 2000.54 0.456 1 12 44 50 128 200 302 480 1000 2000";
     String expected = "This is jedna dziesiąta jedna setna sześć setnych dwa i pięćdziesiąt cztery setne siedemdziesiąt osiem i dziewięćdziesiąt pięć setnych 2000.54 0.456 jeden dwanaście czterdzieści cztery pięćdziesiąt sto dwadzieścia osiem dwieście trzysta dwa czterysta osiemdziesiąt tysiąc 2000";
 
@@ -20,8 +21,9 @@ public class NumberToTextDecoratorTest {
      * Setup of every test
      */
     void setUp() {
+        numberDictionary = new NumberDictionary("src/main/resources/numbersDictionarySource.csv");
         container = new TextContainer(text);
-        decorator = new NumberToTextDecorator(container);
+        decorator = new NumberToTextDecorator(container, numberDictionary);
     }
 
 

--- a/src/test/java/pl/put/poznan/transformer/logic/TextTransformerTest.java
+++ b/src/test/java/pl/put/poznan/transformer/logic/TextTransformerTest.java
@@ -1,20 +1,33 @@
 package pl.put.poznan.transformer.logic;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Array;
+
+import static org.mockito.Mockito.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class TextTransformerTest {
     TextTransformer transformer;
+    NumberDictionary numberDictionary;
+    WordsAndAbbrDictionary wordsAndAbbrDictionary;
     String text = "Hello! I'm about to get Transformed!";
-    String text2 = "Pan Profesor przekazał między innymi, że np. 25 punktów nie wystarczy.";
+    String text2 = "Pan Profesor między innymi przekazał, że np. 25 punktów nie wystarczy.";
     String expected;
+
+    @BeforeEach
+    void setUp() {
+        numberDictionary = mock(NumberDictionary.class);
+        wordsAndAbbrDictionary = mock(WordsAndAbbrDictionary.class);
+    }
 
     @Test
     void testUpper() {
         String[] transforms = {"upper"};
-        transformer = new TextTransformer(transforms);
+        transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
         expected = "HELLO! I'M ABOUT TO GET TRANSFORMED!";
         assertEquals(expected, transformer.transform(text));
     }
@@ -22,7 +35,7 @@ class TextTransformerTest {
     @Test
     void testLower() {
         String[] transforms = {"lower"};
-        transformer = new TextTransformer(transforms);
+        transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
         expected = "hello! i'm about to get transformed!";
         assertEquals(expected, transformer.transform(text));
     }
@@ -30,7 +43,7 @@ class TextTransformerTest {
     @Test
     void testCapitalize() {
         String[] transforms = {"capitalize"};
-        transformer = new TextTransformer(transforms);
+        transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
         expected = "Hello! I'm About To Get Transformed!";
         assertEquals(expected, transformer.transform(text));
     }
@@ -38,7 +51,7 @@ class TextTransformerTest {
     @Test
     void testReverse() {
         String[] transforms = {"reverse"};
-        transformer = new TextTransformer(transforms);
+        transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
         expected = "!demrofSnart teg ot tuobA m'i !olleh";
         assertEquals(expected, transformer.transform(text));
     }
@@ -46,24 +59,35 @@ class TextTransformerTest {
     @Test
     void testNumbersToText() {
         String[] transforms = {"numbersToText"};
-        transformer = new TextTransformer(transforms);
-        expected = "Pan Profesor przekazał między innymi, że np. dwadzieścia pięć punktów nie wystarczy.";
+        when(numberDictionary.isKeyInDictionary("20")).thenReturn(true);
+        when(numberDictionary.isKeyInDictionary("5")).thenReturn(true);
+        when(numberDictionary.getValue("20")).thenReturn("dwadzieścia");
+        when(numberDictionary.getValue("5")).thenReturn("pięć");
+        transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
+        expected = "Pan Profesor między innymi przekazał, że np. dwadzieścia pięć punktów nie wystarczy.";
         assertEquals(expected, transformer.transform(text2));
     }
 
-//    @Test
-//    void testWordToAbbr() {
-//        String[] transforms = {"wordToAbbr"};
-//        transformer = new TextTransformer(transforms);
-//        expected = "Pan Prof. przekazał m.in., że np. 25 punktów nie wystarczy.";
-//        assertEquals(expected, transformer.transform(text2));
-//    }
+    @Test
+    void testWordToAbbr() {
+        String[] transforms = {"wordToAbbr"};
+        String[] words = {"Profesor", "między innymi"};
+        when(wordsAndAbbrDictionary.getListOfWords()).thenReturn(words);
+        when(wordsAndAbbrDictionary.getAbbrFromWord("Profesor")).thenReturn("Prof.");
+        when(wordsAndAbbrDictionary.getAbbrFromWord("między innymi")).thenReturn("m.in.");
+        transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
+        expected = "Pan Prof. m.in. przekazał, że np. 25 punktów nie wystarczy.";
+        assertEquals(expected, transformer.transform(text2));
+    }
 
     @Test
     void testAbbrToWord() {
         String[] transforms = {"abbrToWord"};
-        transformer = new TextTransformer(transforms);
-        expected = "Pan Profesor przekazał między innymi, że na przykład 25 punktów nie wystarczy.";
+        String[] abbrs = {"np."};
+        when(wordsAndAbbrDictionary.getListOfAbbrs()).thenReturn(abbrs);
+        when(wordsAndAbbrDictionary.getWordFromAbbr("np.")).thenReturn("na przykład");
+        transformer = new TextTransformer(transforms, numberDictionary, wordsAndAbbrDictionary);
+        expected = "Pan Profesor między innymi przekazał, że na przykład 25 punktów nie wystarczy.";
         assertEquals(expected, transformer.transform(text2));
     }
 }

--- a/src/test/java/pl/put/poznan/transformer/logic/WordToAbbrDecoratorTest.java
+++ b/src/test/java/pl/put/poznan/transformer/logic/WordToAbbrDecoratorTest.java
@@ -4,23 +4,34 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class WordToAbbrDecoratorTest {
 
     TextContainer container;
     WordToAbbrDecorator decorator;
+    WordsAndAbbrDictionary wordsAndAbbrDictionary;
 
     String text = "Profesory to między innymi na przykład ulica tak zwany profesor";
     String expected = "Profesory to m.in. np. ul. tzw. prof.";
 
     @BeforeEach
     void setUp() {
+        wordsAndAbbrDictionary = mock(WordsAndAbbrDictionary.class);
         container = new TextContainer(text);
-        decorator = new WordToAbbrDecorator(container);
+        decorator = new WordToAbbrDecorator(container, wordsAndAbbrDictionary);
     }
 
     @Test
     void testWordToAbbr() {
+        String[] words = {"między innymi", "na przykład", "ulica", "tak zwany", "profesor"};
+        when(wordsAndAbbrDictionary.getListOfWords()).thenReturn(words);
+        when(wordsAndAbbrDictionary.getAbbrFromWord(words[0])).thenReturn("m.in.");
+        when(wordsAndAbbrDictionary.getAbbrFromWord(words[1])).thenReturn("np.");
+        when(wordsAndAbbrDictionary.getAbbrFromWord(words[2])).thenReturn("ul.");
+        when(wordsAndAbbrDictionary.getAbbrFromWord(words[3])).thenReturn("tzw.");
+        when(wordsAndAbbrDictionary.getAbbrFromWord(words[4])).thenReturn("prof.");
         assertEquals(expected, decorator.transformText());
     }
 


### PR DESCRIPTION
Changed testing classes for TextTransformer, AbbrToWordDecorator, WordToAbbrDecorator and NumberToTextDecorator so that they use mock objects as a replacement for dictionary classes. Also added all necessary changes in many classes so that decorators become independent of instances of dictionary classes.